### PR TITLE
Initialize FastAPI backend scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# adrian3333
+# ISES Field Operations App
+
+This repository contains the initial backend scaffold for the ISES field operations management system. The application is built with FastAPI and will include modules for authentication, route planning, failed visit alerts, vehicle management, and reporting.
+
+## Development
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the development server:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+These endpoints are currently available:
+
+- `GET /health` – basic health check
+- `POST /login` – placeholder for authentication
+- `POST /routes` – placeholder for route generation

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+
+from .schemas import LoginRequest
+
+app = FastAPI(title="ISES Backend")
+
+
+@app.get("/health")
+def health():
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.post("/login")
+def login(request: LoginRequest):
+    """Placeholder login endpoint."""
+    return {"message": f"Login for {request.username} not implemented"}
+
+
+@app.post("/routes")
+def generate_routes():
+    """Placeholder route generation endpoint."""
+    return {"routes": []}

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class Order(BaseModel):
+    id_referencia: str
+    direccion: str
+    localidad: str
+    tiempo_inspeccion: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+pydantic


### PR DESCRIPTION
## Summary
- set up FastAPI application with health, login, and route generation placeholders
- add Pydantic models for login request and order data
- document development workflow and dependencies

## Testing
- `python -m py_compile backend/main.py backend/schemas.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8b623b7848330b0a1abc766bd4664